### PR TITLE
Remove isAdmin function

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -123,7 +123,7 @@ class Application extends AbstractWebApplication implements ContainerAwareInterf
 				try
 				{
 					$this->clearHeaders();
-					$webserviceClient = $input->get->getString('webserviceClient', '');
+					$webserviceClient = $input->get->getString('webserviceClient', 'site');
 					$optionName       = $input->get->getString('option', '');
 					$optionName       = strpos($optionName, 'com_') === 0 ? substr($optionName, 4) : $optionName;
 					$viewName         = $input->getString('view', '');
@@ -135,11 +135,6 @@ class Application extends AbstractWebApplication implements ContainerAwareInterf
 					$task    = $this->getTask();
 					$data    = $this->getPostedData();
 					$dataGet = $input->get->getArray();
-
-					if (empty($webserviceClient))
-					{
-						$webserviceClient = $this->isAdmin() ? 'administrator' : 'site';
-					}
 
 					$options = array(
 						'api'               => $apiName,
@@ -221,17 +216,6 @@ class Application extends AbstractWebApplication implements ContainerAwareInterf
 
 		return ($this->get('webservices.enable_webservices', 0) == 1 && $apiName == 'hal')
 		|| ($this->get('webservices.enable_soap', 0) == 1 && $apiName == 'soap');
-	}
-
-	/**
-	 * Checks whether we are in the site or admin of the Joomla CMS.
-	 *
-	 * @return  bool
-	 * @todo    Implement a check here
-	 */
-	public function isAdmin()
-	{
-		return true;
 	}
 
 	/**


### PR DESCRIPTION
This check was here because in the old RedCore plugin we were calling the CMS `JApplicationCms::isAdmin()` - I just noticed that @chrisdavenport wants to merge the site and admin api's together (https://github.com/joomla-projects/webservices/issues/5) so for now I'm removing this function and just defaulting to site when we try and get a value from the supergobal.
